### PR TITLE
use gsutil for check_md5

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pass_checks | a boolean value where 'true' means the data file fulfilled the min
 
 ## check_md5
 
-Workflow to run an md5sum check on a file and return OK or FAILED.
+Workflow to compare the md5sum in google cloud storage with a user-provided value.
 
 The user must specify the following inputs:
 
@@ -84,10 +84,9 @@ input | description
 --- | ---
 file | Google bucket path to a file.
 md5sum | String with expected md5sum.
-disk_gb | (optional, default 10) Disk size in GB required to run the workflow. Set to a value larger than the input file size.
 
 The workflow returns the following outputs:
 
 output | description
 --- | ---
-md5_check | String with results of check (OK or FAILED)
+md5_check | String with results of check (PASS or FAIL)

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -30,7 +30,7 @@ task results {
     command <<<
         gsutil ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
-        python3 -c "print('PASS' if open('md5_hex.txt').read().strip() == ~{md5sum} else 'FAIL')" > check.txt
+        python3 -c "print('PASS' if open('md5_hex.txt').read().strip() == '~{md5sum}' else 'FAIL')" > check.txt
     >>>
 
     output {


### PR DESCRIPTION
Google cloud objects already have the md5 value accessible via `gsutil ls -L`, but it's in base64 instead of hex. Obtain this value, use python to convert to hex, and compare to the user-supplied value. Requires passing the google cloud bucket path as a string instead of file.