### PR TITLE
workflow fails if check fails

### DIFF
--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -33,16 +33,7 @@ task results {
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         echo "hex checksum: "; cat md5_hex.txt
         echo "hex provided: ~{md5sum}"
-        python3 -c "\
-        md5 =  open('md5_hex.txt').read().strip()\
-        if (md5 == '~{md5sum}'):\
-          print('PASS')\
-        elif (md5 == ''):\
-          print('UNVERIFIED')\
-        else:\
-          print('FAIL')
-        " > check.txt
-        #python3 -c "print('PASS') if open('md5_hex.txt').read().strip() == '~{md5sum}' else 'FAIL'" > check.txt
+        python3 -c "print('PASS') if open('md5_hex.txt').read().strip() == '~{md5sum}' else print('UNVERIFIED') if open('md5_hex.txt').read().strip() == '' else print('FAIL')" > check.txt
         if [ $(<check.txt) = 'FAIL' ]; then
             exit 1
         fi

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -33,7 +33,16 @@ task results {
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         echo "hex checksum: "; cat md5_hex.txt
         echo "hex provided: ~{md5sum}"
-        python3 -c "print('PASS' if open('md5_hex.txt').read().strip() == '~{md5sum}' else 'FAIL')" > check.txt
+        python3 -c "\
+        md5 =  open('md5_hex.txt').read().strip()\
+        if (md5 == '~{md5sum}'):\
+          print('PASS')\
+        elif (md5 == ''):\
+          print('UNVERIFIED')\
+        else:\
+          print('FAIL')
+        " > check.txt
+        #python3 -c "print('PASS') if open('md5_hex.txt').read().strip() == '~{md5sum}' else 'FAIL'" > check.txt
         if [ $(<check.txt) = 'FAIL' ]; then
             exit 1
         fi

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -29,7 +29,10 @@ task results {
 
     command <<<
         gsutil ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
+        echo "b64 checksum: "; cat md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
+        echo "hex checksum: "; cat md5_hex.txt
+        echo "hex provided: ~{md5sum}"
         python3 -c "print('PASS' if open('md5_hex.txt').read().strip() == '~{md5sum}' else 'FAIL')" > check.txt
         if [ $(<check.txt) = 'FAIL' ]; then
             exit 1

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -31,6 +31,9 @@ task results {
         gsutil ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         python3 -c "print('PASS' if open('md5_hex.txt').read().strip() == '~{md5sum}' else 'FAIL')" > check.txt
+        if [ $(<check.txt) = 'FAIL' ]; then
+            exit 1
+        fi
     >>>
 
     output {


### PR DESCRIPTION
The check_md5 workflow now fails if the check fails, making it easier to quickly see the results of the check. The results log prints the checksums for reference, and there is an option for returning UNVERIFIED if the file in google cloud storage does not have an md5 computed (as happens for composite or parallel uploads)