### PR TITLE
project_id in check_md5

### DIFF
--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -4,7 +4,7 @@ workflow check_md5 {
     input {
         String file
         String md5sum
-        String project_id
+        String? project_id
     }
 
     call results {
@@ -27,11 +27,11 @@ task results {
     input {
         String file
         String md5sum
-        String project_id
+        String? project_id
     }
 
     command <<<
-        gsutil -u ~{project_id} ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
+        gsutil ${true='-u ~{project_id}' false='' defined(project_id)}  ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
         echo "b64 checksum: "; cat md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         echo "hex checksum: "; cat md5_hex.txt

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -30,8 +30,10 @@ task results {
         String? project_id
     }
 
+    String project_id_string = if defined(project_id) then "-u " + project_id else ""
+
     command <<<
-        gsutil ~{true='-u ~{project_id}' false='' defined(project_id)}  ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
+        gsutil ~{project_id_string} ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
         echo "b64 checksum: "; cat md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         echo "hex checksum: "; cat md5_hex.txt

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -31,7 +31,7 @@ task results {
     }
 
     command <<<
-        gsutil ${true='-u ~{project_id}' false='' defined(project_id)}  ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
+        gsutil ~{true='-u ~{project_id}' false='' defined(project_id)}  ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
         echo "b64 checksum: "; cat md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         echo "hex checksum: "; cat md5_hex.txt

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -4,11 +4,13 @@ workflow check_md5 {
     input {
         String file
         String md5sum
+        String project_id
     }
 
     call results {
         input: file = file,
-               md5sum = md5sum
+               md5sum = md5sum,
+               project_id = project_id
     }
 
     output {
@@ -25,10 +27,11 @@ task results {
     input {
         String file
         String md5sum
+        String project_id
     }
 
     command <<<
-        gsutil ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
+        gsutil -u ~{project_id} ls -L ~{file} | grep "md5" | awk '{print $3}' > md5_b64.txt
         echo "b64 checksum: "; cat md5_b64.txt
         python3 -c "import base64; import binascii; print(binascii.hexlify(base64.urlsafe_b64decode(open('md5_b64.txt').read())))" | cut -d "'" -f 2 > md5_hex.txt
         echo "hex checksum: "; cat md5_hex.txt


### PR DESCRIPTION
check_md5 will fail for a file in a requester-pays workspace. Add an optional project_id argument that provides a google project to bill so the check will run.