### PR TITLE
Md5 ids optional

### DIFF
--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -66,7 +66,8 @@ task summarize_md5_check {
         Array[String]? id
     }
 
-    Array[String] id2 = select_first([id, range(length(file)) + 1])
+    Array[Int] id_num = range(length(file))
+    Array[String] id2 = select_first([id, id_num])
 
     command <<<
         Rscript -e "\

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -2,19 +2,29 @@ version 1.0
 
 workflow check_md5 {
     input {
-        String file
-        String md5sum
+        Array[String] file
+        Array[String] md5sum
+        Array[String] id
         String? project_id
     }
 
-    call md5check {
-        input: file = file,
-               md5sum = md5sum,
+    
+    scatter (pair in zip(file, md5sum)) {
+        call md5check {
+            input: file = pair.left,
+                md5sum = pair.right,
                project_id = project_id
+        }
+    }
+
+    call summarize_md5_check {
+        input: file = file,
+            md5_check = md5check.md5_check,
+            id = id
     }
 
     output {
-        String md5_check = md5check.md5_check
+        String md5_check_summary = summarize_md5_check.summary
     }
 
      meta {

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -4,7 +4,7 @@ workflow check_md5 {
     input {
         Array[String] file
         Array[String] md5sum
-        Array[String] id
+        #Array[String]? id
         String? project_id
     }
 
@@ -19,8 +19,8 @@ workflow check_md5 {
 
     call summarize_md5_check {
         input: file = file,
-            md5_check = md5check.md5_check,
-            id = id
+            md5_check = md5check.md5_check
+            #id = id
     }
 
     output {

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -63,14 +63,16 @@ task summarize_md5_check {
     input {
         Array[String] file
         Array[String] md5_check
-        Array[String] id
+        Array[String]? id
     }
+
+    Array[String] id2 = select_first([id, range(length(file)) + 1])
 
     command <<<
         Rscript -e "\
         files <- readLines('~{write_lines(file)}'); \
         checks <- readLines('~{write_lines(md5_check)}'); \
-        ids <- readLines('~{write_lines(id)}'); \
+        ids <- readLines('~{write_lines(id2)}'); \
         library(dplyr); \
         dat <- tibble(id=ids, file_path=files, md5_check=checks); \
         readr::write_tsv(dat, 'details.txt'); \


### PR DESCRIPTION
not all workflows that call summarize_md5_check provide ids, so need to make them optional. If not provided, the "id" column in the md5 check "details" file will have 0:(N-1) (since WDL arrays are 0-based)