### PR TITLE
check_md5 fails if md5 is missing

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -10,6 +10,11 @@ workflows:
      primaryDescriptorPath: /check_md5.wdl
      testParameterFiles:
          - /check_md5.json
+   - name: return_md5
+     subclass: WDL
+     primaryDescriptorPath: /return_md5.wdl
+     testParameterFiles:
+         - /return_md5.json
    - name: md5_hex
      subclass: WDL
      primaryDescriptorPath: /md5_hex.wdl

--- a/check_md5.wdl
+++ b/check_md5.wdl
@@ -54,7 +54,7 @@ task md5check {
         echo "hex checksum: "; cat md5_hex.txt
         echo "hex provided: ~{md5sum}"
         python3 -c "print('PASS') if open('md5_hex.txt').read().strip() == '~{md5sum}' else print('UNVERIFIED') if open('md5_hex.txt').read().strip() == '' else print('FAIL')" > check.txt
-        if [[ $(<check.txt) = 'FAIL' ]]; then
+        if [[ $(<check.txt) != 'PASS' ]]; then
             exit 1
         fi
     >>>

--- a/return_md5.wdl
+++ b/return_md5.wdl
@@ -1,0 +1,41 @@
+version 1.0
+
+workflow return_md5 {
+    input {
+        File file_list
+    }
+
+    call md5 {
+        input: file_list = file_list
+    }
+    
+    output {
+        File md5_table = md5.md5_table
+    }
+}
+
+task md5 {
+    input {
+        File file_list
+    }
+
+    command <<<
+        R < RSCRIPT
+            files <- readLines("~{file_list}")
+            md5 <- character(length(files))
+            for (i in seq_along(files)) {
+                md5[i] <- AnVILGCP::gsutil_stat(files[i])[["Hash (md5)"]]
+            }
+            md5_tbl <- tibble(file = files, md5 = md5)
+            write_tsv(md5_tbl, "md5_table.tsv")
+        RSCRIPT   
+    >>>
+
+    output {
+        File md5_table = "md5_table.tsv"
+    }
+
+    runtime {
+        docker: "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.0"
+    }
+}

--- a/return_md5.wdl
+++ b/return_md5.wdl
@@ -20,7 +20,7 @@ task md5 {
     }
 
     command <<<
-        R < RSCRIPT
+        R << RSCRIPT
             files <- readLines("~{file_list}")
             md5 <- character(length(files))
             for (i in seq_along(files)) {

--- a/return_md5.wdl
+++ b/return_md5.wdl
@@ -25,11 +25,11 @@ task md5 {
             md5 <- character(length(files))
             for (i in seq_along(files)) {
                 chk <- AnVIL::gsutil_stat(files[i])[["Hash (md5)"]]
-            }
-            if (is.null(chk)) {
-                md5[i] <- NA
-            } else {
-                md5[i] <- chk
+                if (is.null(chk)) {
+                    md5[i] <- NA
+                } else {
+                    md5[i] <- chk
+                }
             }
             md5_tbl <- tibble::tibble(file = files, md5 = md5)
             readr::write_tsv(md5_tbl, "md5_table.tsv")

--- a/return_md5.wdl
+++ b/return_md5.wdl
@@ -24,7 +24,12 @@ task md5 {
             files <- readLines("~{file_list}")
             md5 <- character(length(files))
             for (i in seq_along(files)) {
-                md5[i] <- AnVIL::gsutil_stat(files[i])[["Hash (md5)"]]
+                chk <- AnVIL::gsutil_stat(files[i])[["Hash (md5)"]]
+            }
+            if (is.null(chk)) {
+                md5[i] <- NA
+            } else {
+                md5[i] <- chk
             }
             md5_tbl <- tibble::tibble(file = files, md5 = md5)
             readr::write_tsv(md5_tbl, "md5_table.tsv")

--- a/return_md5.wdl
+++ b/return_md5.wdl
@@ -24,10 +24,10 @@ task md5 {
             files <- readLines("~{file_list}")
             md5 <- character(length(files))
             for (i in seq_along(files)) {
-                md5[i] <- AnVILGCP::gsutil_stat(files[i])[["Hash (md5)"]]
+                md5[i] <- AnVIL::gsutil_stat(files[i])[["Hash (md5)"]]
             }
-            md5_tbl <- tibble(file = files, md5 = md5)
-            write_tsv(md5_tbl, "md5_table.tsv")
+            md5_tbl <- tibble::tibble(file = files, md5 = md5)
+            readr::write_tsv(md5_tbl, "md5_table.tsv")
         RSCRIPT   
     >>>
 


### PR DESCRIPTION
since AnVIL data release requires valid md5sums for all files, "UNVERIFIED" if the md5 is missing should not allow the workflow to return successfully